### PR TITLE
templateのindexにkeywordによるタグの曖昧検索の実装

### DIFF
--- a/interfaces/controllers/template_controller.go
+++ b/interfaces/controllers/template_controller.go
@@ -26,9 +26,10 @@ func (controller *TemplateController) Index(c Context) {
 	// ページネーション処理
 	pageNumber, _ := strconv.Atoi(c.DefaultQuery("pages", "1"))
 	limit, _ := strconv.Atoi(c.DefaultQuery("limit", "10"))
+	keyword := c.DefaultQuery("keyword", "")
 	offset := limit * (pageNumber - 1)
 
-	templates, total, err := controller.Interactor.ListTemplates(limit, offset)
+	templates, total, err := controller.Interactor.ListTemplates(limit, offset, keyword)
 	if err != nil {
 		c.JSON(controller.Interactor.StatusCode, NewError(err))
 		return

--- a/interfaces/db/template_repository.go
+++ b/interfaces/db/template_repository.go
@@ -25,6 +25,7 @@ func (repo *TemplateRepository) Get(limit int, offset int, keyword string) (temp
 	_, err = repo.Select(&templates, "select templates.id, templates.uid, templates.background_url, templates.generated_sample_url, templates.created_at, templates.updated_at from templates " +
 		"LEFT JOIN template_tags ON templates.id = template_tags.template_id " +
 		"LEFT JOIN tags ON template_tags.tag_id = tags.id " +
+		"order by id desc" +
 		"where tags.title like ? " +
 		"limit ? offset ?",
 		keywordLike, limit, offset)

--- a/interfaces/db/template_repository.go
+++ b/interfaces/db/template_repository.go
@@ -18,9 +18,6 @@ func (repo *TemplateRepository) Count() (count int, err error) {
 }
 
 func (repo *TemplateRepository) Get(limit int, offset int, keyword string) (templates entity.Templates, err error) {
-	//_, err = repo.Select(&templates,
-	//	"select * from templates LEFT JOIN template_tags ON templates.id = template_tags.template_id LEFT JOIN tags ON template_tags.tag_id = tags.id where tags.title = ? limit ? offset ?",
-	//	keyword, limit, offset)
 	keywordLike := "%"+keyword+"%"
 	_, err = repo.Select(&templates, "select templates.id, templates.uid, templates.background_url, templates.generated_sample_url, templates.created_at, templates.updated_at from templates " +
 		"LEFT JOIN template_tags ON templates.id = template_tags.template_id " +

--- a/interfaces/db/template_repository.go
+++ b/interfaces/db/template_repository.go
@@ -17,8 +17,17 @@ func (repo *TemplateRepository) Count() (count int, err error) {
 	return
 }
 
-func (repo *TemplateRepository) Get(limit int, offset int) (templates entity.Templates, err error) {
-	_, err = repo.Select(&templates, "select * from templates order by id desc limit ? offset ?", limit, offset)
+func (repo *TemplateRepository) Get(limit int, offset int, keyword string) (templates entity.Templates, err error) {
+	//_, err = repo.Select(&templates,
+	//	"select * from templates LEFT JOIN template_tags ON templates.id = template_tags.template_id LEFT JOIN tags ON template_tags.tag_id = tags.id where tags.title = ? limit ? offset ?",
+	//	keyword, limit, offset)
+	keywordLike := "%"+keyword+"%"
+	_, err = repo.Select(&templates, "select templates.id, templates.uid, templates.background_url, templates.generated_sample_url, templates.created_at, templates.updated_at from templates " +
+		"LEFT JOIN template_tags ON templates.id = template_tags.template_id " +
+		"LEFT JOIN tags ON template_tags.tag_id = tags.id " +
+		"where tags.title like ? " +
+		"limit ? offset ?",
+		keywordLike, limit, offset)
 	if err != nil {
 		log.Fatalln(err)
 		return

--- a/interfaces/db/template_repository.go
+++ b/interfaces/db/template_repository.go
@@ -25,8 +25,8 @@ func (repo *TemplateRepository) Get(limit int, offset int, keyword string) (temp
 	_, err = repo.Select(&templates, "select templates.id, templates.uid, templates.background_url, templates.generated_sample_url, templates.created_at, templates.updated_at from templates " +
 		"LEFT JOIN template_tags ON templates.id = template_tags.template_id " +
 		"LEFT JOIN tags ON template_tags.tag_id = tags.id " +
-		"order by id desc" +
 		"where tags.title like ? " +
+		"order by id desc " +
 		"limit ? offset ?",
 		keywordLike, limit, offset)
 	if err != nil {

--- a/usecase/template_interactor.go
+++ b/usecase/template_interactor.go
@@ -15,8 +15,8 @@ type TemplateResponse struct {
 	Tags entity.Tags
 }
 
-func (interactor *TemplateInteractor) ListTemplates(limit int, offset int) (t entity.Templates, totalPages int, err error) {
-	t, err = interactor.TemplateRepository.Get(limit, offset)
+func (interactor *TemplateInteractor) ListTemplates(limit int, offset int, keyword string) (t entity.Templates, totalPages int, err error) {
+	t, err = interactor.TemplateRepository.Get(limit, offset, keyword)
 	totalPages, err = interactor.TemplateRepository.Count()
 	if err != nil {
 		interactor.StatusCode = 404

--- a/usecase/template_repository.go
+++ b/usecase/template_repository.go
@@ -4,7 +4,7 @@ import "ca-zoooom/entity"
 
 type TemplateRepository interface {
 	Count() (int, error)
-	Get(limit int, offset int) (entity.Templates, error)
+	Get(limit int, offset int, keyword string) (entity.Templates, error)
 	GetByUniqueId(string) (entity.Template, error)
 	Insert(*entity.Template) error
 }


### PR DESCRIPTION
## Request
`GET /templates?keyword={keyword}&limit={limit}&page={page}`

## Response
```
{
  "pagination":{
    "current_page_num":1,
    "content_count":10,
    "total_pages":1
  },
  "templates": [
    {
      "id":2,
      "uid":"hogehoge",
      "background_url":"https://dgk4i14p4jx9a.cloudfront.net/product/product_img2.png",
      "generated_sample_url":"https://dgk4i14p4jx9a.cloudfront.net/product/product_img2.png",
      "updated_at":"2020-10-07T00:00:00Z",
      "created_at":"2020-10-07T00:00:00Z"
    }
  ]
}
```

## 実装に関して
`where tags.name like %keyword%`で検索かけているので、とりあえずkeywordで渡した単語が含まれれば検索にはかかるはず（逆にいえばちょっとでも違うと検索にかからないのが難点）